### PR TITLE
Comment out failing unit tests in UnitTest1.cs

### DIFF
--- a/src/tests/UnitTest1.cs
+++ b/src/tests/UnitTest1.cs
@@ -22,7 +22,7 @@ namespace MyGithubActionsPresentation.Tests
     {
       Assert.IsTrue(true);
     }
-
+/*
     [TestMethod]
     public void Test4Fails()
     {
@@ -34,7 +34,7 @@ namespace MyGithubActionsPresentation.Tests
     {
       Assert.IsTrue(false);
     }
-
+*/
     [TestMethod]
     public void Test6Passes()
     {


### PR DESCRIPTION
This pull request makes minor changes to the test suite, specifically commenting out two test methods in `src/tests/UnitTest1.cs`. These changes temporarily disable failing tests while keeping passing tests active.